### PR TITLE
rate limit error, expired tokens, permissions

### DIFF
--- a/docs/web/handling-api-limit-errors.md
+++ b/docs/web/handling-api-limit-errors.md
@@ -3,7 +3,15 @@ layout: default
 title: Handling Facebook API Limit Errors
 ---
 
-[TOTO]
+##Handling Facebook API Limit Errors
+If your app recieves a rate limit error you must wait untill Facebook allows your app to start making requests again, this usually happens with in a few hours.  There are no warnings if you are getting close to a rate limit error.  The best way to prevent getting rate limit errors is to always use a user access token to make any API calls, rate limit errors can happen much faster if an app access token is being used to make api calls.  An example would be loading images dynamically making a graph API call each time the page is loaded for each user like this
 
+      <img src="https://graph.facebook.com/{user fbid you want image of}/picture" />
+
+You may not have not realized that just getting this image is actually making a graph API call.  A good way to prevent these images from giving you a rate limit error is to add the user's access token if you have one
+
+      <img src="https://graph.facebook.com/{user fbid you want image of}/picture?access_token=sadlkfuhwakjcbweklcbklerwuagbvlkajgvklreaklherlkjhersc" />
+
+Check any other places in your app where many API calls are being made without an access token, and add an access_token to the call
 
 {% include web-see-also.md %}

--- a/docs/web/handling-expired-access-tokens.md
+++ b/docs/web/handling-expired-access-tokens.md
@@ -38,10 +38,66 @@ Finally, be mindful that there can be errors with Facebook's API. If you make a 
 
 > Currently, you can request a permission called 'offline_access' which grants you an access token that will never expire. This is being deprecated by Facebook and it is no longer recommended you built applications that rely on this type of token.
 
-## Renewing an Access Token
-[TOTO]
+## Requesting Long Term Access Tokens
+According to Facebook doc's standard short term access tokens expire after 1 -2 hours, and extended tokens expire after approx. 60 days.  Don't depend on the 60 day time limit , I have seen extended tokens expire in as little as 30 days.  Extended Access tokens are necessary any time you want to make an API call after the user has ended their session on your app.  For example, telling a user to make a specific post or liking a specific page, then later checking to see if the user has made that specific post after they leave your app.  You have to already have a short term token before requesting the long term token.
+
+        private string GetExtendedAccessToken(string ShortLivedToken)
+        {
+            FacebookClient client = new FacebookClient();
+            string extendedToken = "";
+            try
+            {
+                dynamic result = client.Get("/oauth/access_token", new
+                {
+                    grant_type = "fb_exchange_token",
+                    client_id = "{your app id}",
+                    client_secret = "{your app secret id}",
+                    fb_exchange_token = ShortLivedToken
+                });
+                extendedToken = result.access_token;
+            }
+            catch
+            {
+                extendedToken = ShortLivedToken;
+            }
+            return extendedToken;
+        }
+
+##Getting info and Expire date of Tokens
+The input token will be the token that you are requesting information about, your app access token or a valid user access token from a developer of the app
+
+         FacebookClient client = new FacebookClient();
+         dynamic result = client.Get("debug_token", new
+                           {
+                             input_token = "{input-token} ",
+                             access_token = "{access-token}"
+                           });
+
+The resuls will come back formatted like this.  scope are the extended permissions that were granted with this token.  This request can also be used to check what extended permissions the user has authorized.  Note:  that the issued_at field is not returned for short-lived access tokens.
+
+{
+        "data": {
+            "app_id": 138483919580948, 
+            "application": "Social Cafe", 
+            "expires_at": 1352419328, 
+            "is_valid": true, 
+            "issued_at": 1347235328, 
+            "scopes": [
+                "email", 
+                "publish_actions"
+            ], 
+            "user_id": 1207059
+        }
+    }
+
+
 
 ## Reauthorizing a Users
-[TOTO]
+When making any API call, if any OAuth exception is caught then then user will need to reauthenticate to get a new access token.  This can be done through the Facebook Javascript SDK, or by redirecting the user to the Log In page.
+
+            return Redirect("https://www.facebook.com/dialog/oauth?" +
+                   "client_id=" + "{your app id}" +
+                   "&redirect_uri=" + "{url for Facebook to send access token}");
+
 
 {% include web-see-also.md %}

--- a/docs/web/permissions.md
+++ b/docs/web/permissions.md
@@ -3,6 +3,48 @@ layout: default
 title: Requesting Permissons
 ---
 
-[TODO]
+##Requesting Permissions with Facebook's Javascript SDK
+When using the Javascript SDK built in Login just add the parameter "scope" and add a comma seperated list of the permissions that you would like to request frmo the user.
+
+    	FB.login(function (response) {
+    	    if (response.authResponse) {
+                // user sucessfully logged in
+    	        var accessToken = response.authResponse.accessToken;
+    	    }
+    	}, { scope: 'email,publish_stream,email,rsvp_event,read_stream,user_likes,user_birthday' });
+
+##Requesting Permissions using server side Redirect
+With the server side redirect just add the parameter "scope" in the url with a comma seperated list of the permissions that you are requesting.  The "response_type" parameter can also be added here.  response_type Determines whether the response data included when the redirect back to the app occurs is in URL parameters or fragments.  There are 3 options for the response_type:
+
+       response_type=code : Response data is included as URL parameters and contains code parameter (an encrypted string unique to each login request). This is the default behaviour if this parameter is not                                                        specified. It's most useful when your server will be handling the token.
+       response_type=token : Response data is included as a URL fragment and contains an access token. Desktop apps must use this setting for response_type. This is most useful when the client will be handling the token.
+       response_type=code%20token : Response data is included as a URL fragment and contains both an access token and the code parameter.
+
+
+            return Redirect("https://www.facebook.com/dialog/oauth?" +
+                   "client_id=" + "{your app id}" +
+                   "&redirect_uri=" + "{url for Facebook to send access token}" +
+                   "&scope=email,publish_stream,email,rsvp_event,read_stream,user_likes,user_birthday"
+                   "&response_type=token" );
+
+If you chose response_type=token then the access token will be in the url when Facebook sends a response to the redirect_uri
+
+            http://www.myurl.com?access_token=adlkfnaskldghiwgliawcblksdfklasdlfkjsavcbkjlasdfdk
+
+If you did not specificy response_type or chose "code" then you need exchange code for an access token
+
+            FacebookClient client = new FacebookClient();
+            dynamic result = client.Get("oauth/access_token", new
+            {
+                client_id = "{app-id}",
+                redirect_uri = "{redirect-uri}",
+                client_secret = "{app-secret}",
+                code = "{code-parameter}"
+            });
+
+
+
+
+
 
 {% include web-see-also.md %}


### PR DESCRIPTION
Just filled in parts of the docs where I saw "TODO:"  added to rate limit error page,  the expired token page, and the permissions page
